### PR TITLE
enable ius-archive repo for git2u

### DIFF
--- a/lib/yum.sh
+++ b/lib/yum.sh
@@ -30,5 +30,9 @@ strap::yum::init() {
   fi
   if ! strap::yum::pkg::is_installed 'ius-release'; then # needed for git2u (up to date git and git-credential-libsecret) and python3
     sudo yum -y install 'https://repo.ius.io/ius-release-el7.rpm'
+    if ! strap::yum::pkg::is_installed 'yum-utils'; then
+        yum -y install yum-utils
+    fi
+    sudo yum-config-manager --enable ius-archive
   fi
 }


### PR DESCRIPTION
New url doesn't work for git2u download.
Fix by enabling ius-archive repo based on https://centos.pkgs.org/7/ius-archive-x86_64/git2u-2.14.1-1.ius.centos7.x86_64.rpm.html

@lhazlewood @kelvinzhu-okta