### PR TITLE
Fix straprc for 2 edge cases 

### DIFF
--- a/etc/straprc
+++ b/etc/straprc
@@ -8,7 +8,7 @@ if [[ -d "${HOME}/.strap/releases/current/bin" ]]; then
   export PATH="${HOME}/.strap/releases/current/bin:$PATH"
 fi
 
-if ([[ -n "${ZSH_VERSION}" ]] && setopt +o nomatch; ls -A "${HOME}"/.strap/etc/straprc.d/*.sh >/dev/null 2>&1); then
+if ([[ -n "${ZSH_VERSION}" ]] && setopt +o nomatch; ls "${HOME}"/.strap/etc/straprc.d/*.sh >/dev/null); then
   for file in "${HOME}"/.strap/etc/straprc.d/*.sh; do
     source "${file}"
   done


### PR DESCRIPTION
# Edge case 1 - using an ls alternative
See https://github.com/strapsh/strap/issues/7
This is remediated by surfacing errors so folks can see what is going on.

# Edge case 2 -  using dot files
If you were to put a .test.sh file in straprc.d, it would be picked up by `ls -A`, however, it would NOT be picked up by `for file in "${HOME}"/.strap/etc/straprc.d/*.sh; do`
In this scenario, one of two things could happen:
1. There are only dot-files in straprc.d - this will cause errors because the for-loop globbing will fail
2. There are regular files and dot-files - The dot files will be ignored