### PR TITLE
Uninstall ansible if version not same (needed to upgrade to 2.10)

### DIFF
--- a/lib/ansible.sh
+++ b/lib/ansible.sh
@@ -38,6 +38,10 @@ function strap::ansible::install() {
 
   if [[ -n "${STRAP_ANSIBLE_VERSION}" ]]; then
     strap::running "Ensuring strap virtualenv ansible version ${STRAP_ANSIBLE_VERSION}"
+    ansible_version_installed=$(python -m pip show ansible | grep Version | cut -d' ' -f2) || true
+    if [[ "${ansible_version_installed}" != "${STRAP_ANSIBLE_VERSION}" ]]; then
+      strap::exec python -m pip uninstall -y ansible
+    fi
     strap::exec python -m pip install ansible=="${STRAP_ANSIBLE_VERSION}"
   else
     strap::running "Ensuring strap virtualenv ansible"


### PR DESCRIPTION
Need to update Ansible version to 2.10.5 or greater due to homebrew cask changes which is causing issues: https://github.com/ansible-collections/community.general/issues/1524

In order to update Ansible from 2.9.10 to 2.10, need to uninstall first, then reinstall: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-ansible-on-macos