### PR TITLE
Ensure all ansible packages are uninstalled correctly

### DIFF
--- a/lib/ansible.sh
+++ b/lib/ansible.sh
@@ -40,7 +40,7 @@ function strap::ansible::install() {
     strap::running "Ensuring strap virtualenv ansible version ${STRAP_ANSIBLE_VERSION}"
     ansible_version_installed=$(python -m pip show ansible | grep Version | cut -d' ' -f2) || true
     if [[ "${ansible_version_installed}" != "${STRAP_ANSIBLE_VERSION}" ]]; then
-      strap::exec python -m pip uninstall -y ansible
+      strap::exec python -m pip uninstall -y ansible ansible-base ansible-core
     fi
     strap::exec python -m pip install ansible=="${STRAP_ANSIBLE_VERSION}"
   else


### PR DESCRIPTION
pip install ansible can install ansible, ansible-base, and ansible-core depending on the version, but doing a pip uninstall ansible will only uninstall the ansible package and not the others which can cause issues.