### PR TITLE
return Strap version number

### DIFF
--- a/cmd/version
+++ b/cmd/version
@@ -17,7 +17,7 @@ fi
 
 STRAP_DEBUG="${STRAP_DEBUG:-}" && [[ -n "$STRAP_DEBUG" ]] && set -x
 STRAP_HOME="${STRAP_HOME:-}" && [[ -z "$STRAP_HOME" ]] && echo "STRAP_HOME is not set" && exit 1
-STRAP_VERSION="0.0.1-SNAPSHOT"
+STRAP_VERSION="${STRAP_HOME##*/}"
 
 main() {
 


### PR DESCRIPTION
Get the Strap version number by the last substring after "/" in path.

Tested in my local:
![image](https://github.com/strapsh/strap/assets/108756155/2945362b-5f12-4098-ade5-51a27263b0a4)

"`$STRAP_HOME`" example:  `/Users/randyren/.strap/releases/strap-0.3.11`
